### PR TITLE
Support for dumping variables using 'printf' for testing scenarios where std is not avalible.

### DIFF
--- a/generate/src/generation/mod.rs
+++ b/generate/src/generation/mod.rs
@@ -13,6 +13,7 @@ use mir::syntax::{
     SwitchTargets, Terminator, TyId, TyKind, UnOp, VariantIdx,
 };
 use mir::tyctxt::TyCtxt;
+use mir::VarDumper;
 use rand::seq::SliceRandom;
 use rand::{seq::IteratorRandom, Rng, RngCore, SeedableRng};
 use rand_distr::{Distribution, WeightedError, WeightedIndex};
@@ -921,7 +922,7 @@ impl GenerationCtx {
         for vars in dumpped.chunks(Program::DUMPER_ARITY) {
             let new_bb = self.add_new_bb();
 
-            let args = if self.program.use_debug_dumper {
+            let args = if self.program.var_dumper == VarDumper::StdVarDumper || self.program.var_dumper == VarDumper::PrintfVarDumper{
                 let mut args = Vec::with_capacity(1 + Program::DUMPER_ARITY * 2);
                 args.push(Operand::Constant(
                     self.cursor.function.index().try_into().unwrap(),
@@ -1166,7 +1167,7 @@ impl GenerationCtx {
         }
     }
 
-    pub fn new(seed: u64, debug_dump: bool) -> Self {
+    pub fn new(seed: u64, debug_dump: VarDumper) -> Self {
         let rng = RefCell::new(Box::new(rand::rngs::SmallRng::seed_from_u64(seed)));
         let tcx = Rc::new(seed_tys(&mut *rng.borrow_mut()));
         let ty_weights = TySelect::new(&tcx);

--- a/generate/src/main.rs
+++ b/generate/src/main.rs
@@ -18,7 +18,7 @@ use std::time::Instant;
 
 use clap::{arg, command, value_parser};
 use log::{debug, info};
-use mir::serialize::Serialize;
+use mir::{serialize::Serialize, VarDumper};
 
 use crate::generation::GenerationCtx;
 
@@ -27,6 +27,7 @@ fn main() {
     let matches = command!()
         .args(&[
             arg!(-d --debug "generate a program where values are printed instead of hashed (slow)"),
+            arg!(-p --printf_debug "generate a program where values are printed using the C 'printf' function instead of hashed (slow)"),
             arg!(<seed> "generation seed").value_parser(value_parser!(u64)),
         ])
         .get_matches();
@@ -35,12 +36,19 @@ fn main() {
         .get_one::<u64>("seed")
         .expect("need an integer as seed");
     let debug_dump = matches.get_one::<bool>("debug").copied().unwrap_or(false);
+    let printf_dump = matches.get_one::<bool>("printf_debug").copied().unwrap_or(false);
+    let dumper = match (debug_dump,printf_dump){
+        (false,false)=>VarDumper::HashDumper,
+        (true,false)=>VarDumper::StdVarDumper,
+        (false,true)=>VarDumper::PrintfVarDumper,
+        (true,true)=>panic!("You can only choose either the `debug` dumper or `printf_debug` dumper, but both of them have been selected."),
+    };
     info!("Generating a program with seed {seed}");
-    let genctxt = GenerationCtx::new(seed, debug_dump);
+    let genctxt = GenerationCtx::new(seed, dumper);
     let time = Instant::now();
     let (program, tcx) = genctxt.generate();
     println!("{}", program.serialize(&tcx));
-    println!("{}", tcx.serialize());
+    println!("{}", tcx.serialize(dumper));
     let dur = time.elapsed();
     debug!("took {}s to generate", dur.as_secs_f32());
 }

--- a/generate/src/ty.rs
+++ b/generate/src/ty.rs
@@ -85,7 +85,9 @@ impl TySelect {
                 .unwrap();
             }
             trace!("Typing context with weights:\n{s}");
-            trace!("{}", tcx.serialize());
+            // FractalFir: serialization requires info about which dumper(printf-based one or not) is used. I pass `StdVarDumper` here to preserve 
+            // previous behaviour.  
+            trace!("{}", tcx.serialize(mir::VarDumper::StdVarDumper));
         }
 
         WeightedIndex::new(tcx.iter_enumerated().map(|(tyid, _)| weights[&tyid]))

--- a/mir/src/lib.rs
+++ b/mir/src/lib.rs
@@ -4,3 +4,4 @@
 pub mod serialize;
 pub mod syntax;
 pub mod tyctxt;
+pub const ENABLE_PRINTF_DEBUG:bool = true;

--- a/mir/src/lib.rs
+++ b/mir/src/lib.rs
@@ -5,3 +5,12 @@ pub mod serialize;
 pub mod syntax;
 pub mod tyctxt;
 pub const ENABLE_PRINTF_DEBUG:bool = true;
+#[derive(Clone,Copy,PartialEq, Eq)]
+pub enum VarDumper{
+    /// Print variable hashes
+    HashDumper,
+    /// Print variables using standard rust formatting 
+    StdVarDumper,
+    /// Print variables using the c `printf` function 
+    PrintfVarDumper,
+}

--- a/mir/src/serialize.rs
+++ b/mir/src/serialize.rs
@@ -316,10 +316,15 @@ impl Serialize for Body {
 impl Serialize for Program {
     fn serialize(&self, tcx: &TyCtxt) -> String {
         let mut program = Program::HEADER.to_string();
-        if self.use_debug_dumper {
-            program += Program::DEBUG_DUMPER;
-        } else {
-            program += Program::DUMPER;
+        if crate::ENABLE_PRINTF_DEBUG{
+            program += Program::PRINTF_DUMPER;
+        }
+        else{
+            if self.use_debug_dumper {
+                program += Program::DEBUG_DUMPER;
+            } else {
+                program += Program::DUMPER;
+            }
         }
         program.extend(self.functions.iter_enumerated().map(|(idx, body)| {
             let args_list: String = body

--- a/mir/src/syntax.rs
+++ b/mir/src/syntax.rs
@@ -935,6 +935,42 @@ impl Program {
             unsafe{printf(")\0".as_ptr() as *const c_char)};
         }
     }
+    impl<A:PrintFDebug,B:PrintFDebug,C:PrintFDebug,D:PrintFDebug,E:PrintFDebug,F:PrintFDebug> PrintFDebug for (A,B,C,D,E,F){
+        fn printf_debug(&self){
+            unsafe{printf("(\0".as_ptr() as *const c_char)};
+            self.0.printf_debug();
+            unsafe{printf(",\0".as_ptr() as *const c_char)};
+            self.1.printf_debug();
+            unsafe{printf(",\0".as_ptr() as *const c_char)};
+            self.2.printf_debug();
+            unsafe{printf(",\0".as_ptr() as *const c_char)};
+            self.3.printf_debug();
+            unsafe{printf(",\0".as_ptr() as *const c_char)};
+            self.4.printf_debug();
+            unsafe{printf(",\0".as_ptr() as *const c_char)};
+            self.5.printf_debug();
+            unsafe{printf(")\0".as_ptr() as *const c_char)};
+        }
+    }
+    impl<A:PrintFDebug,B:PrintFDebug,C:PrintFDebug,D:PrintFDebug,E:PrintFDebug,F:PrintFDebug,G:PrintFDebug> PrintFDebug for (A,B,C,D,E,F,G){
+        fn printf_debug(&self){
+            unsafe{printf("(\0".as_ptr() as *const c_char)};
+            self.0.printf_debug();
+            unsafe{printf(",\0".as_ptr() as *const c_char)};
+            self.1.printf_debug();
+            unsafe{printf(",\0".as_ptr() as *const c_char)};
+            self.2.printf_debug();
+            unsafe{printf(",\0".as_ptr() as *const c_char)};
+            self.3.printf_debug();
+            unsafe{printf(",\0".as_ptr() as *const c_char)};
+            self.4.printf_debug();
+            unsafe{printf(",\0".as_ptr() as *const c_char)};
+            self.5.printf_debug();
+            unsafe{printf(",\0".as_ptr() as *const c_char)};
+            self.6.printf_debug();
+            unsafe{printf(")\0".as_ptr() as *const c_char)};
+        }
+    }
     #[inline(never)]
     fn dump_var(
         f: usize,


### PR DESCRIPTION
I was interested in using this project to detect bugs in my experimental codegen backend. I don't have support for Rust formatting yet, so I tried to get `rustlantis` to work without using the standard Rust lib.

 This pull request adds the ability to dump variables using `printf` instead of the standard Rust formatter, when the `--printf_debug` option is specified.