### PR TITLE
Avoid generating consecutive assignments to the same place

### DIFF
--- a/generate/src/generation/mod.rs
+++ b/generate/src/generation/mod.rs
@@ -1,5 +1,6 @@
 mod intrinsics;
 
+use std::cell::Cell;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::{cmp, fmt, vec};
@@ -66,6 +67,7 @@ pub struct GenerationCtx {
     saved_ctx: Vec<SavedCtx>,
     cursor: Cursor,
     config: GenerationConfig,
+    previous_lhs: Cell<Option<Place>>,
 }
 
 // Operand
@@ -448,11 +450,23 @@ impl GenerationCtx {
 // Statement
 impl GenerationCtx {
     fn generate_assign(&self) -> Result<Statement> {
-        let (lhs_choices, weights) = PlaceSelector::for_lhs(self.tcx.clone())
+        let (lhs_choices, mut weights) = PlaceSelector::for_lhs(self.tcx.clone())
             .into_weighted(&self.pt)
             .ok_or(SelectionError::Exhausted)?;
 
-        self.make_choice_weighted(lhs_choices.into_iter(), weights, |ppath| {
+        if let Some(prev) = self.previous_lhs.take() {
+            for (i, choice) in lhs_choices.iter().enumerate() {
+                let choice = choice.to_place(&self.pt);
+                if choice == prev {
+                    weights
+                        .update_weights(&[(i, &0)])
+                        .map_err(|_| SelectionError::Exhausted)?;
+                    break;
+                }
+            }
+        }
+
+        let stmt = self.make_choice_weighted(lhs_choices.into_iter(), weights, |ppath| {
             let lhs = ppath.to_place(&self.pt);
             trace!(
                 "generating an assignment statement with lhs {}: {}",
@@ -460,9 +474,13 @@ impl GenerationCtx {
                 lhs.ty(self.current_decls(), &self.tcx).serialize(&self.tcx)
             );
 
+            self.previous_lhs.set(Some(lhs.clone()));
+
             let statement = Statement::Assign(lhs.clone(), self.generate_rvalue(&lhs)?);
             Ok(statement)
-        })
+        });
+
+        stmt
     }
 
     // Hack to take &self
@@ -919,6 +937,7 @@ impl GenerationCtx {
 
     /// Terminates the current BB, and moves the generation context to the new BB
     fn choose_terminator(&mut self) -> bool {
+        self.previous_lhs.set(None);
         assert!(matches!(self.current_bb().terminator(), Terminator::Hole));
         if self.pt.can_return() {
             if Place::RETURN_SLOT.complexity(&self.pt) > 10
@@ -1202,6 +1221,7 @@ impl GenerationCtx {
             },
             saved_ctx: vec![],
             config: config.generation,
+            previous_lhs: Cell::new(None),
         }
     }
 


### PR DESCRIPTION
Currently, rustlantis tends to generate a lot of assignments to the same place within the same basic block. This is especially silly when the assignments to the same place occur next to each other. For example, this is the first basic block that comes out of `generate` with seed 0:
```
{
_1 = !63487_u16;
_4 = !1390730785_u32;
RET = 9852_i16 as f64;
_3 = (-138109794282916576908390722958742720726_i128) << _1;
_4 = !688210538_u32;
_1 = !35107_u16;
RET = _3 as f64;
_4 = 562135920_u32 + 3663929644_u32;
RET = (-2719951640687674442_i64) as f64;
_3 = 1981794491838386707_u64 as i128;
RET = 5_usize as f64;
_3 = 125582680801400656974857784996786910228_i128 + (-49121485659754867407561513453388421295_i128);
_1 = 31074_u16;
_6 = -RET;
_6 = RET - RET;
_4 = !3232469644_u32;
_2 = '\u{65a79}';
_2 = '\u{756c8}';
_8 = _1 >> _3;
_2 = '\u{216e4}';
_3 = 126_u8 as i128;
_8 = _1 & _1;
_6 = RET * RET;
Goto(bb1)
}
```
In particular, I think this is wasteful:
```
_6 = -RET;
_6 = RET - RET;
```
```
_2 = '\u{65a79}';
_2 = '\u{756c8}';
```

So this PR is a _very_ hacky way to prevent those. It works, but I'd appreciate advice on making it more elegant.